### PR TITLE
Add teamlibrary permission to plugin manifest

### DIFF
--- a/packages/plugin/manifest.json
+++ b/packages/plugin/manifest.json
@@ -12,5 +12,5 @@
     "allowedDomains": ["http://localhost:38451"],
     "reasoning": "Required for CLI bridge communication"
   },
-  "permissions": ["currentuser"]
+  "permissions": ["currentuser", "teamlibrary"]
 }


### PR DESCRIPTION
Enables access to team library features in the Figma plugin by adding the teamlibrary permission alongside the existing currentuser permission.

## Description

This PR adds the `teamlibrary` permission to the Figma plugin manifest, enabling the plugin to access and interact with team library components, styles, and assets. This permission is required for features that need to read or work with shared team resources.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update


## Changes Made

- Added `teamlibrary` permission to `packages/plugin/manifest.json`
- Permission is added alongside existing `currentuser` permission

## Testing

- [x] Tested in Figma Desktop
- [x] Tested with MCP client (Claude/Cursor)
- [x] Tested CLI commands
- [ ] Added/updated tests

### Test Steps

1. Install the plugin in Figma with the updated manifest
2. Verify the plugin can access team library components
3. Confirm no errors related to permissions appear in the console
4. Test any features that interact with team library resources

## Screenshots/Examples

N/A - Permission change only, no visual changes

## Checklist

 - [x] My code follows the project's style guidelines
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published

## Additional Notes

This is a prerequisite change for implementing features that interact with Figma team libraries. The permission itself is non-breaking and will not affect existing functionality.
